### PR TITLE
fix: add async await to app.Run and counting funcs

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -21,4 +21,5 @@ YardHandler.Map(app);
 EmployeeHandler.Map(app);
 // Vehicle Routes
 VehicleHandler.Map(app);
-app.Run();
+
+await app.RunAsync();

--- a/repos/yard-employee/YardEmployeeRepository.cs
+++ b/repos/yard-employee/YardEmployeeRepository.cs
@@ -34,7 +34,7 @@ namespace AutoInsightAPI.Repositories
 
       public async Task<PagedResponse<YardEmployee>> ListPagedAsync(int page, int pageSize, Yard yard)
       {
-        var totalRecords = _db.YardEmployees.Where(ye => ye.YardId == yard.Id).Count();
+        var totalRecords = await _db.YardEmployees.Where(ye => ye.YardId == yard.Id).CountAsync();
 
         var employees = await _db.YardEmployees
           .AsNoTracking()

--- a/repos/yard-vehicle/YardVehicleRepository.cs
+++ b/repos/yard-vehicle/YardVehicleRepository.cs
@@ -28,7 +28,7 @@ namespace AutoInsightAPI.Repositories
 
       public async Task<PagedResponse<YardVehicle>> ListPagedAsync(int page, int pageSize, Yard yard)
       {
-        var totalRecords = _db.YardVehicles.Where(yv => yv.YardId == yard.Id).Count();
+        var totalRecords = await _db.YardVehicles.Where(yv => yv.YardId == yard.Id).CountAsync();
 
         var vehicles = await _db.YardVehicles
           .AsNoTracking()


### PR DESCRIPTION
This pull request makes a few minor improvements to asynchronous handling and database queries in the application. The main changes are switching to async methods where appropriate to avoid blocking operations.

**Asynchronous improvements:**

* Changed application startup to use `await app.RunAsync()` instead of `app.Run()` in `Program.cs` for proper async handling.

**Database query optimizations:**

* Updated `YardEmployeeRepository.cs` and `YardVehicleRepository.cs` to use `CountAsync()` instead of `Count()` for counting records in paged list queries, ensuring the operations are non-blocking and properly await the database. [[1]](diffhunk://#diff-61ee9a59c2045c0097079ea157d1888891d19dec5e2a088d152e50f32c599d7dL37-R37) [[2]](diffhunk://#diff-3bf65d793c9e64b5cf1ded332583efff4c57c7bad579937210114c35f858c860L31-R31)