### PR TITLE
fix: add double quotes to variables on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ RUN dotnet restore "./AutoInsightAPI.csproj"
 
 COPY . .
 WORKDIR "/src/."
-RUN dotnet build "./AutoInsightAPI.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "./AutoInsightAPI.csproj" -c "$BUILD_CONFIGURATION" -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./AutoInsightAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./AutoInsightAPI.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app


### PR DESCRIPTION
This pull request makes a minor improvement to the `Dockerfile` by quoting the `$BUILD_CONFIGURATION` variable in the `dotnet build` and `dotnet publish` commands. This change helps prevent issues if the build configuration contains spaces or special characters.

- Quoted the `$BUILD_CONFIGURATION` variable in both the `dotnet build` and `dotnet publish` commands to improve reliability and prevent potential errors.