### PR TITLE
fix: change 'throw error' to 'throw' to preserve trace

### DIFF
--- a/repos/yard/YardRepository.cs
+++ b/repos/yard/YardRepository.cs
@@ -37,7 +37,7 @@ namespace AutoInsightAPI.Repositories
 
             Console.WriteLine(error);
 
-            throw error;
+            throw;
         }
       }
 


### PR DESCRIPTION
This pull request makes a minor change to the error handling in the `CreateAsync` method of the `YardRepository` class. Instead of re-throwing the caught exception object, it now uses a plain `throw;` statement to preserve the original stack trace, which is a best practice for exception handling in C#.

- Updated exception re-throwing in `CreateAsync` to use `throw;` instead of `throw error;` for better stack trace preservation (`repos/yard/YardRepository.cs`)