### PR TITLE
refactor: add const for qrcodes table name

### DIFF
--- a/Migrations/20250522001650_UpdateQRCodeSchema.cs
+++ b/Migrations/20250522001650_UpdateQRCodeSchema.cs
@@ -7,20 +7,22 @@ namespace AutoInsightAPI.Migrations
     /// <inheritdoc />
     public partial class UpdateQRCodeSchema : Migration
     {
+        private const string QRCODE_TABLE = "QRCodes";
+        
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropForeignKey(
                 name: "FK_QRCodes_Yards_YardId",
-                table: "QRCodes");
+                table: QRCODE_TABLE);
 
             migrationBuilder.DropIndex(
                 name: "IX_QRCodes_YardId",
-                table: "QRCodes");
+                table: QRCODE_TABLE);
 
             migrationBuilder.DropColumn(
                 name: "YardId",
-                table: "QRCodes");
+                table: QRCODE_TABLE);
         }
 
         /// <inheritdoc />
@@ -28,19 +30,19 @@ namespace AutoInsightAPI.Migrations
         {
             migrationBuilder.AddColumn<string>(
                 name: "YardId",
-                table: "QRCodes",
+                table: QRCODE_TABLE,
                 type: "NVARCHAR2(450)",
                 nullable: false,
                 defaultValue: "");
 
             migrationBuilder.CreateIndex(
                 name: "IX_QRCodes_YardId",
-                table: "QRCodes",
+                table: QRCODE_TABLE,
                 column: "YardId");
 
             migrationBuilder.AddForeignKey(
                 name: "FK_QRCodes_Yards_YardId",
-                table: "QRCodes",
+                table: QRCODE_TABLE,
                 column: "YardId",
                 principalTable: "Yards",
                 principalColumn: "Id",


### PR DESCRIPTION
This pull request refactors the `UpdateQRCodeSchema` migration to reduce repetition and improve maintainability by introducing a constant for the `QRCodes` table name. All references to the table name within the migration methods now use this constant.

Migration code refactoring:

* Introduced a private constant `QRCODE_TABLE` to represent the `"QRCodes"` table name, replacing all hardcoded instances in the migration methods for easier future updates and reduced risk of typos.