### PR TITLE
refactor: add const for yard id name

### DIFF
--- a/Migrations/20250522001650_UpdateQRCodeSchema.cs
+++ b/Migrations/20250522001650_UpdateQRCodeSchema.cs
@@ -8,6 +8,7 @@ namespace AutoInsightAPI.Migrations
     public partial class UpdateQRCodeSchema : Migration
     {
         private const string QRCODE_TABLE = "QRCodes";
+        private const string YARD_ID_NAME = "YardId";
         
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -21,7 +22,7 @@ namespace AutoInsightAPI.Migrations
                 table: QRCODE_TABLE);
 
             migrationBuilder.DropColumn(
-                name: "YardId",
+                name: YARD_ID_NAME,
                 table: QRCODE_TABLE);
         }
 
@@ -29,7 +30,7 @@ namespace AutoInsightAPI.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<string>(
-                name: "YardId",
+                name: YARD_ID_NAME,
                 table: QRCODE_TABLE,
                 type: "NVARCHAR2(450)",
                 nullable: false,
@@ -38,12 +39,12 @@ namespace AutoInsightAPI.Migrations
             migrationBuilder.CreateIndex(
                 name: "IX_QRCodes_YardId",
                 table: QRCODE_TABLE,
-                column: "YardId");
+                column: YARD_ID_NAME);
 
             migrationBuilder.AddForeignKey(
                 name: "FK_QRCodes_Yards_YardId",
                 table: QRCODE_TABLE,
-                column: "YardId",
+                column: YARD_ID_NAME,
                 principalTable: "Yards",
                 principalColumn: "Id",
                 onDelete: ReferentialAction.Cascade);


### PR DESCRIPTION
This pull request updates the `UpdateQRCodeSchema` migration to use a constant for the `YardId` column name instead of hardcoding the string. This change improves maintainability and reduces the risk of errors from typos.

Migration schema consistency:

* Introduced the `YARD_ID_NAME` constant to represent the `YardId` column name, replacing all hardcoded usages in the migration methods (`Up` and `Down`).
* Updated all references to the `YardId` column in `DropColumn`, `AddColumn`, `CreateIndex`, and `AddForeignKey` to use the new constant, ensuring consistency throughout the migration. [[1]](diffhunk://#diff-2848b3d5f8483c4a46378a3dc051254e48829826893dd4aa7274ccfa2d259516L24-R33) [[2]](diffhunk://#diff-2848b3d5f8483c4a46378a3dc051254e48829826893dd4aa7274ccfa2d259516L41-R47)