### PR TITLE
fix: define const

### DIFF
--- a/Migrations/20250519165312_InitialSchema.cs
+++ b/Migrations/20250519165312_InitialSchema.cs
@@ -8,16 +8,16 @@ namespace AutoInsightAPI.Migrations
     /// <inheritdoc />
     public partial class InitialSchema : Migration
     {
-        private const string IdColumnType = "NVARCHAR2(450)";
-        private const string StringColumnType = "NVARCHAR2(2000)";
-        private const string DateTimeColumnType = "TIMESTAMP(7)";
-        private const string YardsTableName = "Yards";
-        private const string VehiclesTableName = "Vehicles";
-        private const string YardEmployeesTableName = "YardEmployees";
-        private const string QRCodesTableName = "QRCodes";
-        private const string YardVehiclesTableName = "YardVehicles";
-        private const string EmployeeInvitesTableName = "EmployeeInvites";
-        private const string YardIdColumnName = "YardId";
+        private const string ID_COLUMN = "NVARCHAR2(450)";
+        private const string STRING_COLUMN = "NVARCHAR2(2000)";
+        private const string DATETIMME_COLUMN = "TIMESTAMP(7)";
+        private const string YARD_TABLE = "Yards";
+        private const string VEHICLE_TABLE = "Vehicles";
+        private const string YARD_EMPLOYEE_TABLE = "YardEmployees";
+        private const string QRCODE_TABLE = "QRCodes";
+        private const string YARD_VEHICLE_TABLE = "YardVehicles";
+        private const string EMPLOYEE_INVITE_TABLE = "EmployeeInvites";
+        private const string YARD_ID_COLUMN = "YardId";
 
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -26,13 +26,13 @@ namespace AutoInsightAPI.Migrations
                 name: "Addresses",
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
-                    Country = table.Column<string>(type: StringColumnType, nullable: false),
-                    State = table.Column<string>(type: StringColumnType, nullable: false),
-                    City = table.Column<string>(type: StringColumnType, nullable: false),
-                    ZipCode = table.Column<string>(type: StringColumnType, nullable: false),
-                    Neighborhood = table.Column<string>(type: StringColumnType, nullable: false),
-                    Complement = table.Column<string>(type: StringColumnType, nullable: true)
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    Country = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    State = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    City = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    ZipCode = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    Neighborhood = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    Complement = table.Column<string>(type: STRING_COLUMN, nullable: true)
                 },
                 constraints: table =>
                 {
@@ -43,11 +43,11 @@ namespace AutoInsightAPI.Migrations
                 name: "Bookings",
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
-                    OccursAt = table.Column<DateTime>(type: DateTimeColumnType, nullable: false),
-                    CancelledAt = table.Column<DateTime>(type: DateTimeColumnType, nullable: true),
-                    VehicleId = table.Column<string>(type: StringColumnType, nullable: false),
-                    YardId = table.Column<string>(type: StringColumnType, nullable: false)
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    OccursAt = table.Column<DateTime>(type: DATETIMME_COLUMN, nullable: false),
+                    CancelledAt = table.Column<DateTime>(type: DATETIMME_COLUMN, nullable: true),
+                    VehicleId = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    YardId = table.Column<string>(type: STRING_COLUMN, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -58,8 +58,8 @@ namespace AutoInsightAPI.Migrations
                 name: "Models",
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
-                    Name = table.Column<string>(type: StringColumnType, nullable: false),
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    Name = table.Column<string>(type: STRING_COLUMN, nullable: false),
                     Year = table.Column<int>(type: "NUMBER(10)", nullable: false)
                 },
                 constraints: table =>
@@ -68,12 +68,12 @@ namespace AutoInsightAPI.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: YardsTableName,
+                name: YARD_TABLE,
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
-                    AddressId = table.Column<string>(type: IdColumnType, nullable: false),
-                    OwnerId = table.Column<string>(type: StringColumnType, nullable: false)
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    AddressId = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    OwnerId = table.Column<string>(type: STRING_COLUMN, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -87,13 +87,13 @@ namespace AutoInsightAPI.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: VehiclesTableName,
+                name: VEHICLE_TABLE,
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
-                    Plate = table.Column<string>(type: StringColumnType, nullable: false),
-                    ModelId = table.Column<string>(type: IdColumnType, nullable: false),
-                    UserId = table.Column<string>(type: StringColumnType, nullable: false)
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    Plate = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    ModelId = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    UserId = table.Column<string>(type: STRING_COLUMN, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -107,15 +107,15 @@ namespace AutoInsightAPI.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: YardEmployeesTableName,
+                name: YARD_EMPLOYEE_TABLE,
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
-                    Name = table.Column<string>(type: StringColumnType, nullable: false),
-                    ImageUrl = table.Column<string>(type: StringColumnType, nullable: false),
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    Name = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    ImageUrl = table.Column<string>(type: STRING_COLUMN, nullable: false),
                     Role = table.Column<int>(type: "NUMBER(10)", nullable: false),
-                    UserId = table.Column<string>(type: StringColumnType, nullable: false),
-                    YardId = table.Column<string>(type: IdColumnType, nullable: false)
+                    UserId = table.Column<string>(type: STRING_COLUMN, nullable: false),
+                    YardId = table.Column<string>(type: ID_COLUMN, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -123,18 +123,18 @@ namespace AutoInsightAPI.Migrations
                     table.ForeignKey(
                         name: "FK_YardEmployees_Yards_YardId",
                         column: x => x.YardId,
-                        principalTable: YardsTableName,
+                        principalTable: YARD_TABLE,
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
-                name: QRCodesTableName,
+                name: QRCODE_TABLE,
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
-                    VehicleId = table.Column<string>(type: IdColumnType, nullable: true),
-                    YardId = table.Column<string>(type: IdColumnType, nullable: false)
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    VehicleId = table.Column<string>(type: ID_COLUMN, nullable: true),
+                    YardId = table.Column<string>(type: ID_COLUMN, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -142,26 +142,26 @@ namespace AutoInsightAPI.Migrations
                     table.ForeignKey(
                         name: "FK_QRCodes_Vehicles_VehicleId",
                         column: x => x.VehicleId,
-                        principalTable: VehiclesTableName,
+                        principalTable: VEHICLE_TABLE,
                         principalColumn: "Id");
                     table.ForeignKey(
                         name: "FK_QRCodes_Yards_YardId",
                         column: x => x.YardId,
-                        principalTable: YardsTableName,
+                        principalTable: YARD_TABLE,
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
-                name: YardVehiclesTableName,
+                name: YARD_VEHICLE_TABLE,
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
                     Status = table.Column<int>(type: "NUMBER(10)", nullable: false),
-                    EnteredAt = table.Column<DateTime>(type: DateTimeColumnType, nullable: false),
-                    LeftAt = table.Column<DateTime>(type: DateTimeColumnType, nullable: true),
-                    VehicleId = table.Column<string>(type: IdColumnType, nullable: false),
-                    YardId = table.Column<string>(type: IdColumnType, nullable: false)
+                    EnteredAt = table.Column<DateTime>(type: DATETIMME_COLUMN, nullable: false),
+                    LeftAt = table.Column<DateTime>(type: DATETIMME_COLUMN, nullable: true),
+                    VehicleId = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    YardId = table.Column<string>(type: ID_COLUMN, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -169,24 +169,24 @@ namespace AutoInsightAPI.Migrations
                     table.ForeignKey(
                         name: "FK_YardVehicles_Vehicles_VehicleId",
                         column: x => x.VehicleId,
-                        principalTable: VehiclesTableName,
+                        principalTable: VEHICLE_TABLE,
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_YardVehicles_Yards_YardId",
                         column: x => x.YardId,
-                        principalTable: YardsTableName,
+                        principalTable: YARD_TABLE,
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
-                name: EmployeeInvitesTableName,
+                name: EMPLOYEE_INVITE_TABLE,
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: IdColumnType, nullable: false),
-                    YardEmployeeId = table.Column<string>(type: IdColumnType, nullable: false),
-                    YardId = table.Column<string>(type: IdColumnType, nullable: false)
+                    Id = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    YardEmployeeId = table.Column<string>(type: ID_COLUMN, nullable: false),
+                    YardId = table.Column<string>(type: ID_COLUMN, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -194,61 +194,61 @@ namespace AutoInsightAPI.Migrations
                     table.ForeignKey(
                         name: "FK_EmployeeInvites_YardEmployees_YardEmployeeId",
                         column: x => x.YardEmployeeId,
-                        principalTable: YardEmployeesTableName,
+                        principalTable: YARD_EMPLOYEE_TABLE,
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_EmployeeInvites_Yards_YardId",
                         column: x => x.YardId,
-                        principalTable: YardsTableName,
+                        principalTable: YARD_TABLE,
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateIndex(
                 name: "IX_EmployeeInvites_YardEmployeeId",
-                table: EmployeeInvitesTableName,
+                table: EMPLOYEE_INVITE_TABLE,
                 column: "YardEmployeeId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_EmployeeInvites_YardId",
-                table: EmployeeInvitesTableName,
-                column: YardIdColumnName);
+                table: EMPLOYEE_INVITE_TABLE,
+                column: YARD_ID_COLUMN);
 
             migrationBuilder.CreateIndex(
                 name: "IX_QRCodes_VehicleId",
-                table: QRCodesTableName,
+                table: QRCODE_TABLE,
                 column: "VehicleId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_QRCodes_YardId",
-                table: QRCodesTableName,
-                column: YardIdColumnName);
+                table: QRCODE_TABLE,
+                column: YARD_ID_COLUMN);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Vehicles_ModelId",
-                table: VehiclesTableName,
+                table: VEHICLE_TABLE,
                 column: "ModelId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_YardEmployees_YardId",
-                table: YardEmployeesTableName,
-                column: YardIdColumnName);
+                table: YARD_EMPLOYEE_TABLE,
+                column: YARD_ID_COLUMN);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Yards_AddressId",
-                table: YardsTableName,
+                table: YARD_TABLE,
                 column: "AddressId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_YardVehicles_VehicleId",
-                table: YardVehiclesTableName,
+                table: YARD_VEHICLE_TABLE,
                 column: "VehicleId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_YardVehicles_YardId",
-                table: YardVehiclesTableName,
-                column: YardIdColumnName);
+                table: YARD_VEHICLE_TABLE,
+                column: YARD_ID_COLUMN);
         }
 
         /// <inheritdoc />
@@ -258,22 +258,22 @@ namespace AutoInsightAPI.Migrations
                 name: "Bookings");
 
             migrationBuilder.DropTable(
-                name: EmployeeInvitesTableName);
+                name: EMPLOYEE_INVITE_TABLE);
 
             migrationBuilder.DropTable(
-                name: QRCodesTableName);
+                name: QRCODE_TABLE);
 
             migrationBuilder.DropTable(
-                name: YardVehiclesTableName);
+                name: YARD_VEHICLE_TABLE);
 
             migrationBuilder.DropTable(
-                name: YardEmployeesTableName);
+                name: YARD_EMPLOYEE_TABLE);
 
             migrationBuilder.DropTable(
-                name: VehiclesTableName);
+                name: VEHICLE_TABLE);
 
             migrationBuilder.DropTable(
-                name: YardsTableName);
+                name: YARD_TABLE);
 
             migrationBuilder.DropTable(
                 name: "Models");


### PR DESCRIPTION
This pull request refactors the initial migration schema to improve maintainability and consistency by introducing constants for column types and table names, and then using those constants throughout the migration. This reduces repetition and the risk of typos in string literals, making future changes easier and safer.

**Schema constants and usage:**

* Added constants for column types (e.g., `ID_COLUMN`, `STRING_COLUMN`, `DATETIMME_COLUMN`) and table names (e.g., `YARD_TABLE`, `VEHICLE_TABLE`) at the top of the migration class for reuse.

**Table creation and column definitions:**

* Updated all table creation calls to use the new table name constants instead of string literals, and replaced hardcoded column type strings with the corresponding constants for all columns. [[1]](diffhunk://#diff-8c8b78a1e280756922e38aff3d8d129d6a8c271fd6df738ce207b61e80e6f446L60-R76) [[2]](diffhunk://#diff-8c8b78a1e280756922e38aff3d8d129d6a8c271fd6df738ce207b61e80e6f446L79-R96) [[3]](diffhunk://#diff-8c8b78a1e280756922e38aff3d8d129d6a8c271fd6df738ce207b61e80e6f446L99-R251) [[4]](diffhunk://#diff-8c8b78a1e280756922e38aff3d8d129d6a8c271fd6df738ce207b61e80e6f446L35-R50) [[5]](diffhunk://#diff-8c8b78a1e280756922e38aff3d8d129d6a8c271fd6df738ce207b61e80e6f446L50-R62)

**Foreign key and index references:**

* Changed all foreign key and index definitions to use the new table name and column name constants, ensuring consistency across relationships and indexes.

**Down migration consistency:**

* Updated the `Down` migration to use the table name constants when dropping tables, mirroring the changes made in the `Up` migration for consistency.