### PR TITLE
feat(api)!: implement HATEOAS support for API responses

### DIFF
--- a/configs/ServicesConfigurator.cs
+++ b/configs/ServicesConfigurator.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using AutoInsightAPI.models;
 using AutoInsightAPI.Profiles;
 using AutoInsightAPI.Repositories;
+using AutoInsightAPI.Services;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.EntityFrameworkCore;
 
@@ -23,6 +24,9 @@ public static class ServicesConfigurator
         services.AddScoped<IYardEmployeeRepository, YardEmployeeRepository>();
         services.AddScoped<IYardVehicleRepository, YardVehicleRepository>();
         services.AddScoped<IVehicleRepository, VehicleRepository>();
+
+        services.AddHttpContextAccessor();
+        services.AddScoped<ILinkService, LinkService>();
 
         services.Configure<JsonOptions>(options =>
         {

--- a/dtos/common/HateoasResourceDto.cs
+++ b/dtos/common/HateoasResourceDto.cs
@@ -1,0 +1,6 @@
+namespace AutoInsightAPI.Dtos.Common;
+
+public abstract class HateoasResourceDto
+{
+    public List<LinkDto> Links { get; set; } = new();
+}

--- a/dtos/common/LinkDto.cs
+++ b/dtos/common/LinkDto.cs
@@ -1,0 +1,10 @@
+namespace AutoInsightAPI.Dtos.Common;
+
+public class LinkDto
+{
+    public string Href { get; set; } = string.Empty;
+    public string Rel { get; set; } = string.Empty;
+    public string Method { get; set; } = string.Empty;
+    public string? Title { get; set; }
+    public string? Type { get; set; }
+}

--- a/dtos/common/PagedResponseDTO.cs
+++ b/dtos/common/PagedResponseDTO.cs
@@ -1,6 +1,8 @@
+using AutoInsightAPI.Dtos.Common;
+
 namespace AutoInsightAPI.Dtos
 {
-  public record PagedResponseDto<T>
+  public class PagedResponseDto<T> : HateoasResourceDto
   {
       public int PageNumber { get; set; }
       public int PageSize { get; set; }

--- a/dtos/vehicle/VehicleDTO.cs
+++ b/dtos/vehicle/VehicleDTO.cs
@@ -1,6 +1,8 @@
+using AutoInsightAPI.Dtos.Common;
+
 namespace AutoInsightAPI.Dtos
 {
-  public class VehicleDto
+  public class VehicleDto : HateoasResourceDto
   {
     public string Id {get; set;}
     public string Plate {get; set;}

--- a/dtos/yard-employee/YardEmployeeDTO.cs
+++ b/dtos/yard-employee/YardEmployeeDTO.cs
@@ -1,8 +1,9 @@
 using AutoInsightAPI.Models;
+using AutoInsightAPI.Dtos.Common;
 
 namespace AutoInsightAPI.Dtos
 {
-  public class YardEmployeeDto
+  public class YardEmployeeDto : HateoasResourceDto
   {
     public string Id {get; private set;}
     public string Name {get; set;}

--- a/dtos/yard-vehicle/YardVehicleDTO.cs
+++ b/dtos/yard-vehicle/YardVehicleDTO.cs
@@ -1,8 +1,9 @@
 using AutoInsightAPI.Models;
+using AutoInsightAPI.Dtos.Common;
 
 namespace AutoInsightAPI.Dtos
 {
-  public class YardVehicleDto
+  public class YardVehicleDto : HateoasResourceDto
   {
     public string Id {get; private set;}
     public Status Status {get; set;}

--- a/dtos/yard/YardDTO.cs
+++ b/dtos/yard/YardDTO.cs
@@ -1,6 +1,8 @@
+using AutoInsightAPI.Dtos.Common;
+
 namespace AutoInsightAPI.Dtos
 {
-  public class YardDto
+  public class YardDto : HateoasResourceDto
   {
     public string Id {get; private set;}
 

--- a/services/ILinkService.cs
+++ b/services/ILinkService.cs
@@ -1,0 +1,11 @@
+using AutoInsightAPI.Dtos.Common;
+
+namespace AutoInsightAPI.Services;
+
+public interface ILinkService
+{
+    string GenerateLink(string routeName, object? routeValues = null);
+    string GenerateLink(string action, string controller, object? routeValues = null);
+    List<LinkDto> GenerateResourceLinks(string resourceType, string resourceId, bool includeRelated = true);
+    List<LinkDto> GenerateCollectionLinks(string resourceType, int pageNumber, int pageSize, int totalPages);
+}

--- a/services/LinkService.cs
+++ b/services/LinkService.cs
@@ -1,0 +1,214 @@
+using System.Globalization;
+using AutoInsightAPI.Dtos.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace AutoInsightAPI.Services;
+
+public class LinkService : ILinkService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly LinkGenerator _linkGenerator;
+
+    public LinkService(IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _linkGenerator = linkGenerator;
+    }
+
+    public string GenerateLink(string routeName, object? routeValues = null)
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext == null)
+            throw new InvalidOperationException("HttpContext is not available");
+
+        var link = _linkGenerator.GetUriByName(httpContext, routeName, routeValues);
+        return link ?? string.Empty;
+    }
+
+    public string GenerateLink(string action, string controller, object? routeValues = null)
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext == null)
+            throw new InvalidOperationException("HttpContext is not available");
+
+        var link = _linkGenerator.GetUriByAction(httpContext, action, controller, routeValues);
+        return link ?? string.Empty;
+    }
+
+    public List<LinkDto> GenerateResourceLinks(string resourceType, string resourceId, bool includeRelated = true)
+    {
+        var links = new List<LinkDto>();
+        var httpContext = _httpContextAccessor.HttpContext;
+        
+        if (httpContext == null) return links;
+
+        var baseUrl = GetBaseUrl(httpContext);
+        var resourcePath = resourceType.Split('/').Last();
+        var resourceName = ToTitleCase(resourcePath.TrimEnd('s'));
+
+        // Self link
+        links.Add(new LinkDto
+        {
+            Href = $"{baseUrl}/{resourceType.ToLower()}/{resourceId}",
+            Rel = "self",
+            Method = "GET",
+            Title = $"Get {resourceName} Details",
+            Type = "application/json"
+        });
+
+        // Update link
+        links.Add(new LinkDto
+        {
+            Href = $"{baseUrl}/{resourceType.ToLower()}/{resourceId}",
+            Rel = "update",
+            Method = "PATCH",
+            Title = $"Update {resourceName}",
+            Type = "application/json"
+        });
+
+        // Delete link
+        links.Add(new LinkDto
+        {
+            Href = $"{baseUrl}/{resourceType.ToLower()}/{resourceId}",
+            Rel = "delete",
+            Method = "DELETE",
+            Title = $"Delete {resourceName}",
+            Type = "application/json"
+        });
+
+        // Related resources based on resource type
+        if (includeRelated)
+        {
+            switch (resourceType.ToLower())
+            {
+                case "yard":
+                    links.Add(new LinkDto
+                    {
+                        Href = $"{baseUrl}/yards/{resourceId}/employees",
+                        Rel = "employees",
+                        Method = "GET",
+                        Title = "List Yard Employees",
+                        Type = "application/json"
+                    });
+                    links.Add(new LinkDto
+                    {
+                        Href = $"{baseUrl}/yards/{resourceId}/vehicles",
+                        Rel = "vehicles",
+                        Method = "GET",
+                        Title = "List Yard Vehicles",
+                        Type = "application/json"
+                    });
+                    break;
+                case "vehicle":
+                    links.Add(new LinkDto
+                    {
+                        Href = $"{baseUrl}/vehicles?qrCodeId={resourceId}",
+                        Rel = "qr-code",
+                        Method = "GET",
+                        Title = "Get Vehicle by QR Code",
+                        Type = "application/json"
+                    });
+                    break;
+            }
+        }
+
+        return links;
+    }
+
+    public List<LinkDto> GenerateCollectionLinks(string resourceType, int pageNumber, int pageSize, int totalPages)
+    {
+        var links = new List<LinkDto>();
+        var httpContext = _httpContextAccessor.HttpContext;
+        
+        if (httpContext == null) return links;
+
+        var baseUrl = GetBaseUrl(httpContext);
+        var resourcePath = resourceType.ToLower();
+        var resourceName = ToTitleCase(resourceType.Split('/').Last());
+
+        // Self link
+        links.Add(new LinkDto
+        {
+            Href = $"{baseUrl}/{resourcePath}?pageNumber={pageNumber}&pageSize={pageSize}",
+            Rel = "self",
+            Method = "GET",
+            Title = $"List {resourceName}",
+            Type = "application/json"
+        });
+
+        // Create link
+        links.Add(new LinkDto
+        {
+            Href = $"{baseUrl}/{resourcePath}",
+            Rel = "create",
+            Method = "POST",
+            Title = $"Create New {resourceName}",
+            Type = "application/json"
+        });
+
+        // Pagination links
+        if (pageNumber > 1)
+        {
+            links.Add(new LinkDto
+            {
+                Href = $"{baseUrl}/{resourcePath}?pageNumber={pageNumber - 1}&pageSize={pageSize}",
+                Rel = "prev",
+                Method = "GET",
+                Title = "Previous Page",
+                Type = "application/json"
+            });
+        }
+
+        if (pageNumber < totalPages)
+        {
+            links.Add(new LinkDto
+            {
+                Href = $"{baseUrl}/{resourcePath}?pageNumber={pageNumber + 1}&pageSize={pageSize}",
+                Rel = "next",
+                Method = "GET",
+                Title = "Next Page",
+                Type = "application/json"
+            });
+        }
+
+        // First page
+        if (pageNumber > 1)
+        {
+            links.Add(new LinkDto
+            {
+                Href = $"{baseUrl}/{resourcePath}?pageNumber=1&pageSize={pageSize}",
+                Rel = "first",
+                Method = "GET",
+                Title = "First Page",
+                Type = "application/json"
+            });
+        }
+
+        // Last page
+        if (pageNumber < totalPages)
+        {
+            links.Add(new LinkDto
+            {
+                Href = $"{baseUrl}/{resourcePath}?pageNumber={totalPages}&pageSize={pageSize}",
+                Rel = "last",
+                Method = "GET",
+                Title = "Last Page",
+                Type = "application/json"
+            });
+        }
+
+        return links;
+    }
+
+    private static string GetBaseUrl(HttpContext httpContext)
+    {
+        var request = httpContext.Request;
+        return $"{request.Scheme}://{request.Host}";
+    }
+    
+    private static string ToTitleCase(string str)
+    {
+        return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(str.Replace("-", " "));
+    }
+}


### PR DESCRIPTION
## What & Why
This pull request introduces HATEOAS (Hypermedia As The Engine Of Application State) support across the API. The primary motivation is to enhance API discoverability and navigability by embedding relevant links directly within resource and collection responses. This allows clients to dynamically interact with the API based on the links provided, rather than relying on hardcoded URIs.

## How
-   A new `LinkService` has been implemented to generate HATEOAS links for various resources and collections.
-   A base DTO, `HateoasResourceDto`, was created, which other DTOs now inherit from to include a `Links` property.
-   All GET endpoints for individual resources and collections have been updated to utilize the `LinkService` and include appropriate links such as self, related resources, and pagination links.
-   Update endpoints across the API have been changed from PUT to PATCH. This change better reflects the semantics of partial updates, aligning with common HATEOAS API design patterns.

## Testing
Manual testing of API endpoints was performed to verify correct link generation in responses and to confirm the new PATCH behavior for updates.

## Breaking Changes
-   API responses for all resources and collections now include a new `Links` property containing an array of HATEOAS links.
-   All API update endpoints previously using `PUT` now expect `PATCH` requests. Consumers of the API will need to update their clients to use `PATCH` for resource updates.